### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scraper-schedule.yml
+++ b/.github/workflows/scraper-schedule.yml
@@ -1,5 +1,8 @@
 name: Scheduled Disaster Alert Scraper
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run every 15 minutes


### PR DESCRIPTION
Potential fix for [https://github.com/KCprsnlcc/disaster-alert-aggregator-ph/security/code-scanning/1](https://github.com/KCprsnlcc/disaster-alert-aggregator-ph/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow only needs to read the repository contents (e.g., to check out the code), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privileges necessary to complete the workflow tasks.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
