### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -8,6 +8,9 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch: {}  # Allows manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KCprsnlcc/disaster-alert-aggregator-ph/security/code-scanning/3](https://github.com/KCprsnlcc/disaster-alert-aggregator-ph/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs basic tasks like checking out code, installing dependencies, and running a scraper, it likely only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
